### PR TITLE
recognize 2-level function calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,72 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.10] - 2021-04-24
+### Added
+
+* support for resolving multiple level function calls e.g. `package.logic.do_stuff()`
+* CHANGELOG
+
+## [0.2.9] - 2021-04-23
+### Added
+
+* Codecov configuration
+
+## [0.2.8] - 2021-04-22
+### Changed
+
+* some documentation
+
+## [0.2.7] - 2021-04-22
+### Added
+
+* basic GitHub Actions workflow
+
+## [0.2.6] - 2021-04-22
+### Added
+
+* error handling for Redis instance not supporting `GRAPH` commands
+* error handling for ResponseError from the RedisGraph client library
+* docstrings
+
+## [0.2.5] - 2021-04-21
+### Added
+
+* devtools/requirements.txt
+* pre-commit hook to generate devtools/requirements.txt
+* info about contributing using a development environment without Poetry
+
+## [0.2.3] - 2021-04-21
+### Added
+
+* README: PyPI and Black badges
+* README: links to homepage
+
+### Changed
+
+* README: relative links => absolute links
+
+## [0.2.2] - 2021-04-20
+### Added
+
+* project metadata
+
+## [0.2.1] - 2021-04-20
+### Added
+
+* PyPI config
+
+
+## [0.2.0] - 2021-04-20
+### Added
+
+* a basic RedisGraph model representing a Python project
+* nodes: packages, modules, functions, classes, constants
+* edges: contains, imports, calls
+* distinction between test and production code
+* distinction between different test types

--- a/README.md
+++ b/README.md
@@ -92,7 +92,6 @@ The following imports will be ignored by Pycograph:
 ### Calls
 
 * All the limitations of the imports.
-* Resolving longer calls of more than 2 levels.
 
 ### Other Known Limitations
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pycograph"
-version = "0.2.9"
+version = "0.2.10"
 description = "Create a RedisGraph model of a Python code base."
 authors = ["reka <reka@hey.com>"]
 license = "BSD-3-Clause"

--- a/tests/integration/parse_project/test_import_and_call.py
+++ b/tests/integration/parse_project/test_import_and_call.py
@@ -38,6 +38,12 @@ def other():
     assert len(project.objects) == 5
 
     other_function_object = project.objects["package.importer.other"]
+    calls_do_stuff_rel = CallsRelationship(
+        destination_full_name="package.logic.do_stuff",
+        syntax_element=CallSyntaxElement(
+            what_reference_name="package", called_attribute="logic.do_stuff"
+        ),
+    )
     calls_logic_rel = CallsRelationship(
         destination_full_name="package.logic",
         syntax_element=CallSyntaxElement(
@@ -48,5 +54,8 @@ def other():
         destination_full_name="package",
         syntax_element=CallSyntaxElement(what_reference_name="package"),
     )
-    # Expected behavior: It should also find a call to package.logic.do_stuff
-    assert other_function_object.relationships == [calls_logic_rel, calls_package_rel]
+    assert other_function_object.relationships == [
+        calls_do_stuff_rel,
+        calls_logic_rel,
+        calls_package_rel,
+    ]

--- a/tests/unit/test_pycograph.py
+++ b/tests/unit/test_pycograph.py
@@ -2,4 +2,4 @@ from pycograph import __version__
 
 
 def test_version():
-    assert __version__ == "0.2.9"
+    assert __version__ == "0.2.10"


### PR DESCRIPTION
e.g. package.logic.do_stuff()

Refactoring

* parsing attribute: add condition: ctx Load
* renaming: line => ast_obj

Docs

* add CHANGELOG
* update README: remove limitation with 2-level function calls

version 0.2.10